### PR TITLE
fix prefix search paging

### DIFF
--- a/cmd/range.go
+++ b/cmd/range.go
@@ -151,7 +151,7 @@ func keyAndOptsForRange(args []string) (string, []client.OpOption) {
 				return zero, []client.OpOption{client.WithRange(zero), client.WithLimit(rangeLimit)}
 			}
 			// prefix search
-			return key, []client.OpOption{client.WithPrefix(), client.WithLimit(rangeLimit)}
+			return key, []client.OpOption{client.WithRange(client.GetPrefixRangeEnd(key)), client.WithLimit(rangeLimit)}
 		}
 		// get by ID
 		return key, []client.OpOption{client.WithLimit(rangeLimit)}


### PR DESCRIPTION
when `client.WithPrefix()` was used the `rangeEnd` was with each call to Regatta computed again, which caused that original `rangeEnd` was lost, instead let's use `client.WithRange(client.GetPrefixRangeEnd(key))` to compute the `rangeEnd` once 