### PR TITLE
make shared Regatta subcommands flags global

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ Available Commands:
   version     Get current version of regatta-client and a Regatta server
 
 Flags:
-  -h, --help       help for regatta-client
-      --no-color   disable color output
-  -v, --version    version for regatta-client
+      --cert string             Regatta CA cert
+      --dial-timeout duration   timeout for establishing the connection to the Regatta (default 2s)
+      --endpoint string         Regatta API endpoint (default "localhost:8443")
+  -h, --help                    help for regatta-client
+      --insecure                allow insecure connection, controls whether certificates are validated
+      --no-color                disable color output
+      --timeout duration        timeout for the Regatta operation (default 10s)
+  -v, --version                 version for regatta-client
 
 Use "regatta-client [command] --help" for more information about a command.
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,16 +45,12 @@ var (
 )
 
 func init() {
-	// register common flags directly to the subcommands
-	for _, c := range []*cobra.Command{&RangeCmd, &DeleteCmd, &PutCmd, &VersionCmd, &TableCmd} {
-		c.Flags().StringVar(&endpointOption, "endpoint", "localhost:8443", "Regatta API endpoint")
-		c.Flags().BoolVar(&insecureOption, "insecure", false, "allow insecure connection, controls whether certificates are validated")
-		c.Flags().StringVar(&certOption, "cert", "", "Regatta CA cert")
-		c.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "timeout for the Regatta operation")
-		c.Flags().DurationVar(&dialTimeout, "dial-timeout", 2*time.Second, "timeout for establishing the connection to the Regatta")
-	}
-
 	RootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable color output")
+	RootCmd.PersistentFlags().StringVar(&endpointOption, "endpoint", "localhost:8443", "Regatta API endpoint")
+	RootCmd.PersistentFlags().BoolVar(&insecureOption, "insecure", false, "allow insecure connection, controls whether certificates are validated")
+	RootCmd.PersistentFlags().StringVar(&certOption, "cert", "", "Regatta CA cert")
+	RootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 10*time.Second, "timeout for the Regatta operation")
+	RootCmd.PersistentFlags().DurationVar(&dialTimeout, "dial-timeout", 2*time.Second, "timeout for establishing the connection to the Regatta")
 
 	RootCmd.AddCommand(&RangeCmd)
 	RootCmd.AddCommand(&DeleteCmd)


### PR DESCRIPTION
this also seems to fix issue with parsing boolean flags at certain positions